### PR TITLE
Fix enemy first attack invalid issue

### DIFF
--- a/Config/DefaultEngine.ini
+++ b/Config/DefaultEngine.ini
@@ -16,3 +16,14 @@ GlobalDefaultGameMode=/Script/Blade.BladeGameModeBase
 EditorStartupMap=/Game/Maps/Arena.Arena
 GameDefaultMap=/Game/Maps/Arena.Arena
 
+[/Script/GameplayDebugger.GameplayDebuggerConfig]
+CategorySlot5=Five
+CategorySlot6=Six
+CategorySlot4=Four
+CategorySlot3=Three
+CategorySlot2=Two
+CategorySlot1=One
+CategorySlot7=Seven
+CategorySlot8=Eight
+CategorySlot9=Nine
+

--- a/Content/Assets/ParagonCrunch/Characters/Heroes/Crunch/Animations/Ability_Combo_01_Montage.uasset
+++ b/Content/Assets/ParagonCrunch/Characters/Heroes/Crunch/Animations/Ability_Combo_01_Montage.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4f235dead454ccfe99c6d90e8459a1b7e2ffaa2b0fb41d624f9f2bb888782e8b
+oid sha256:9bef9750402862a004b1e62a97ac65189cbad4349a1dc351d8b1667ee5aa831f
 size 111709

--- a/Content/Assets/ParagonCrunch/Characters/Heroes/Crunch/Animations/LevelStart_Montage.uasset
+++ b/Content/Assets/ParagonCrunch/Characters/Heroes/Crunch/Animations/LevelStart_Montage.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b5eec07c36a7e4fb47a267f8744b976848d82953f87ed930637772d86cf698ef
-size 99733
+oid sha256:e1b259b6e905e506a6570f91372a9f8a8d5580ccea0e4af25c39ef2b94e88b31
+size 101316

--- a/Content/Assets/ParagonKwang/Characters/Heroes/Kwang/Animations/PrimaryAttack_C_Slow_Montage.uasset
+++ b/Content/Assets/ParagonKwang/Characters/Heroes/Kwang/Animations/PrimaryAttack_C_Slow_Montage.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8c0bdbaa67877fc41c77d8cb5c5eef91b8feb330282699f4047e8bf31946d8f9
-size 102585
+oid sha256:275d97078fa2be271cd2627759f0944bfbe1c22edb09069f4cb5c28562bd4cce
+size 102684

--- a/Content/Blueprints/AnimNotifies/AN_WeaponHit.uasset
+++ b/Content/Blueprints/AnimNotifies/AN_WeaponHit.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:461f1dbd6a5bb5adaa5bf5f6eb3d8254fe902a910ee5a95c14e34ae8318870ec
-size 3754
+oid sha256:382aed41836a61f07075ed0c2f9b6802a873b3151dbd5c07a9f8b58d4df3816a
+size 3734

--- a/Source/Blade/Private/AI/BladeAIController.cpp
+++ b/Source/Blade/Private/AI/BladeAIController.cpp
@@ -1,7 +1,6 @@
 #include "BladeAIController.h"
 #include "BehaviorTree/BehaviorTree.h"
 #include "BehaviorTree/BlackboardComponent.h"
-#include "BladeEnemyCharacter.h"
 #include "Perception/AIPerceptionComponent.h"
 #include "Perception/AISense_Sight.h"
 
@@ -9,6 +8,16 @@ ABladeAIController::ABladeAIController()
 {
 	AIPerceptionComponent = CreateDefaultSubobject<UAIPerceptionComponent>(TEXT("AIPerception"));
 	SetPerceptionComponent(*AIPerceptionComponent);
+}
+
+void ABladeAIController::PauseLogic(const FString& Reason)
+{
+	GetBrainComponent()->PauseLogic(Reason);
+}
+
+void ABladeAIController::ResumeLogic(const FString& Reason)
+{
+	GetBrainComponent()->ResumeLogic(Reason);
 }
 
 void ABladeAIController::OnPossess(APawn* InPawn)

--- a/Source/Blade/Private/Animations/AnimNotifyState_BlockAILogic.cpp
+++ b/Source/Blade/Private/Animations/AnimNotifyState_BlockAILogic.cpp
@@ -1,0 +1,29 @@
+#include "AnimNotifyState_BlockAILogic.h"
+#include "BladeAIController.h"
+#include "BladeCharacterBase.h"
+
+void UAnimNotifyState_BlockAILogic::NotifyBegin(USkeletalMeshComponent* MeshComp, UAnimSequenceBase* Animation, float TotalDuration)
+{
+	ABladeCharacterBase* Character = Cast<ABladeCharacterBase>(MeshComp->GetOwner());
+	if (Character)
+	{
+		ABladeAIController* Controller = Character->GetController<ABladeAIController>();
+		if (Controller)
+		{
+			Controller->PauseLogic(TEXT("Playing Montage"));
+		}
+	}
+}
+
+void UAnimNotifyState_BlockAILogic::NotifyEnd(USkeletalMeshComponent* MeshComp, UAnimSequenceBase* Animation)
+{
+	ABladeCharacterBase* Character = Cast<ABladeCharacterBase>(MeshComp->GetOwner());
+	if (Character)
+	{
+		ABladeAIController* Controller = Character->GetController<ABladeAIController>();
+		if (Controller)
+		{
+			Controller->ResumeLogic(TEXT("Montage was finish played"));
+		}
+	}
+}

--- a/Source/Blade/Private/Animations/AnimNotifyState_BlockInput.cpp
+++ b/Source/Blade/Private/Animations/AnimNotifyState_BlockInput.cpp
@@ -1,8 +1,8 @@
-#include "BladeAnimNotifyState_BlockInput.h"
+#include "AnimNotifyState_BlockInput.h"
 #include "BladeCharacterBase.h"
 #include "BladePlayerControllerBase.h"
 
-void UBladeAnimNotifyState_BlockInput::NotifyBegin(USkeletalMeshComponent* MeshComp, UAnimSequenceBase* Animation, float TotalDuration)
+void UAnimNotifyState_BlockInput::NotifyBegin(USkeletalMeshComponent* MeshComp, UAnimSequenceBase* Animation, float TotalDuration)
 {
 	ABladeCharacterBase* Character = Cast<ABladeCharacterBase>(MeshComp->GetOwner());
 	if (Character)
@@ -15,7 +15,7 @@ void UBladeAnimNotifyState_BlockInput::NotifyBegin(USkeletalMeshComponent* MeshC
 	}
 }
 
-void UBladeAnimNotifyState_BlockInput::NotifyEnd(USkeletalMeshComponent* MeshComp, UAnimSequenceBase* Animation)
+void UAnimNotifyState_BlockInput::NotifyEnd(USkeletalMeshComponent* MeshComp, UAnimSequenceBase* Animation)
 {
 	ABladeCharacterBase* Character = Cast<ABladeCharacterBase>(MeshComp->GetOwner());
 	if (Character)

--- a/Source/Blade/Private/Animations/AnimNotify_WeaponHit.cpp
+++ b/Source/Blade/Private/Animations/AnimNotify_WeaponHit.cpp
@@ -1,7 +1,7 @@
-#include "BladeAnimNotify_WeaponHit.h"
+#include "AnimNotify_WeaponHit.h"
 #include "BladeCharacterBase.h"
 
-void UBladeAnimNotify_WeaponHit::Notify(USkeletalMeshComponent* MeshComp, UAnimSequenceBase* Animation)
+void UAnimNotify_WeaponHit::Notify(USkeletalMeshComponent* MeshComp, UAnimSequenceBase* Animation)
 {
 	Super::Notify(MeshComp, Animation);
 

--- a/Source/Blade/Public/AI/BladeAIController.h
+++ b/Source/Blade/Public/AI/BladeAIController.h
@@ -16,6 +16,9 @@ class BLADE_API ABladeAIController : public AAIController
 public:
 	ABladeAIController();
 
+	virtual void PauseLogic(const FString& Reason);
+	virtual void ResumeLogic(const FString& Reason);
+
 protected:
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "AI")
 	UAIPerceptionComponent* AIPerceptionComponent;

--- a/Source/Blade/Public/Animations/AnimNotifyState_BlockAILogic.h
+++ b/Source/Blade/Public/Animations/AnimNotifyState_BlockAILogic.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Animation/AnimNotifies/AnimNotifyState.h"
+#include "AnimNotifyState_BlockAILogic.generated.h"
+
+UCLASS()
+class BLADE_API UAnimNotifyState_BlockAILogic : public UAnimNotifyState
+{
+	GENERATED_BODY()
+
+public:
+	virtual void NotifyBegin(USkeletalMeshComponent* MeshComp, UAnimSequenceBase* Animation, float TotalDuration) override;
+	virtual void NotifyEnd(USkeletalMeshComponent* MeshComp, UAnimSequenceBase* Animation) override;
+};

--- a/Source/Blade/Public/Animations/AnimNotifyState_BlockInput.h
+++ b/Source/Blade/Public/Animations/AnimNotifyState_BlockInput.h
@@ -2,10 +2,10 @@
 
 #include "CoreMinimal.h"
 #include "Animation/AnimNotifies/AnimNotifyState.h"
-#include "BladeAnimNotifyState_BlockInput.generated.h"
+#include "AnimNotifyState_BlockInput.generated.h"
 
 UCLASS()
-class BLADE_API UBladeAnimNotifyState_BlockInput : public UAnimNotifyState
+class BLADE_API UAnimNotifyState_BlockInput : public UAnimNotifyState
 {
 	GENERATED_BODY()
 

--- a/Source/Blade/Public/Animations/AnimNotify_WeaponHit.h
+++ b/Source/Blade/Public/Animations/AnimNotify_WeaponHit.h
@@ -3,10 +3,10 @@
 #include "CoreMinimal.h"
 #include "GameplayTagContainer.h"
 #include "Animation/AnimNotifies/AnimNotify.h"
-#include "BladeAnimNotify_WeaponHit.generated.h"
+#include "AnimNotify_WeaponHit.generated.h"
 
 UCLASS()
-class BLADE_API UBladeAnimNotify_WeaponHit : public UAnimNotify
+class BLADE_API UAnimNotify_WeaponHit : public UAnimNotify
 {
 	GENERATED_BODY()
 


### PR DESCRIPTION
## Description
- The enemy will play the start animation when the game start. But the behavior tree is also running, the jog animation and the start animation blending cause the position of the attack bone not correct. ANd it will cause the enemy first attack can't hit the player. Therefore, I pause the behavior tree when playing the start animation.
- Rename the animation notify name. It's easy to name more than 32 characters, so remove 'Blade'.
- Modify the gameplay debug shortcut keys because I don't have a number pad. Can be easier to use AI Debugging.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Style modification
