### PR TITLE
Register AI sense source manually

### DIFF
--- a/Config/DefaultGame.ini
+++ b/Config/DefaultGame.ini
@@ -1,3 +1,7 @@
 
 [/Script/EngineSettings.GeneralProjectSettings]
 ProjectID=5FCFC51243BF6235908BB39CAA8641F8
+
+[/Script/AIModule.AISense_Sight]
+bAutoRegisterAllPawnsAsSources=false
+bAutoRegisterNewPawnsAsSources=false

--- a/Content/Blueprints/BP_PlayerCharacter.uasset
+++ b/Content/Blueprints/BP_PlayerCharacter.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ad2a09c98fd04a0ab67794287056a26e15640bffd608ff2798addeea845dc5ec
-size 112464
+oid sha256:133c49e8f3a3f84cb5b4fadb9ec59216f48f9441cb9f16d712fa295a97cb333a
+size 112990

--- a/Source/Blade/Private/BladeCharacterBase.cpp
+++ b/Source/Blade/Private/BladeCharacterBase.cpp
@@ -9,13 +9,12 @@
 #include "Kismet/GameplayStatics.h"
 #include "Kismet/KismetSystemLibrary.h"
 
-ABladeCharacterBase::ABladeCharacterBase(const FObjectInitializer& ObjectInitializer)
-	: Super(ObjectInitializer)
+ABladeCharacterBase::ABladeCharacterBase()
 {
-	AbilitySystemComponent = ObjectInitializer.CreateDefaultSubobject<UBladeAbilitySystemComponent>(this, TEXT("AbilitySystemComponent"));
+	AbilitySystemComponent = CreateDefaultSubobject<UBladeAbilitySystemComponent>(TEXT("AbilitySystemComponent"));
 	AbilitySystemComponent->SetIsReplicated(true);
 
-	AttributeSet = ObjectInitializer.CreateDefaultSubobject<UBladeAttributeSet>(this, TEXT("AttributeSet"));
+	AttributeSet = CreateDefaultSubobject<UBladeAttributeSet>(TEXT("AttributeSet"));
 }
 
 void ABladeCharacterBase::PossessedBy(AController* NewController)

--- a/Source/Blade/Private/BladeEnemyCharacter.cpp
+++ b/Source/Blade/Private/BladeEnemyCharacter.cpp
@@ -3,12 +3,11 @@
 #include "BladeHealthBarWidget.h"
 #include "Components/WidgetComponent.h"
 
-ABladeEnemyCharacter::ABladeEnemyCharacter(const FObjectInitializer& ObjectInitializer)
-	: Super(ObjectInitializer)
+ABladeEnemyCharacter::ABladeEnemyCharacter()
 {
 	AIControllerClass = ABladeAIController::StaticClass();
 
-	WidgetComponent = ObjectInitializer.CreateDefaultSubobject<UWidgetComponent>(this, TEXT("HPWidget"));
+	WidgetComponent = CreateDefaultSubobject<UWidgetComponent>(TEXT("HPWidget"));
 	WidgetComponent->SetupAttachment(RootComponent);
 	WidgetComponent->SetWidgetSpace(EWidgetSpace::Screen);
 	WidgetComponent->SetDrawSize(FVector2D(100, 16));

--- a/Source/Blade/Private/BladePlayerCharacter.cpp
+++ b/Source/Blade/Private/BladePlayerCharacter.cpp
@@ -1,6 +1,12 @@
 #include "BladePlayerCharacter.h"
 #include "BladeGameModeBase.h"
 #include "Kismet/GameplayStatics.h"
+#include "Perception/AIPerceptionStimuliSourceComponent.h"
+
+ABladePlayerCharacter::ABladePlayerCharacter()
+{
+	StimuliSourceComponent = CreateDefaultSubobject<UAIPerceptionStimuliSourceComponent>(TEXT("StimuliSourceComponent"));
+}
 
 void ABladePlayerCharacter::HandleHealthChanged(float DeltaValue, const FGameplayTagContainer& EventTags)
 {

--- a/Source/Blade/Public/BladeCharacterBase.h
+++ b/Source/Blade/Public/BladeCharacterBase.h
@@ -17,7 +17,7 @@ class BLADE_API ABladeCharacterBase : public ACharacter, public IAbilitySystemIn
 	GENERATED_BODY()
 
 public:
-	explicit ABladeCharacterBase(const FObjectInitializer& ObjectInitializer);
+	ABladeCharacterBase();
 
 	virtual void PossessedBy(AController* NewController) override;
 	virtual void OnRep_PlayerState() override;

--- a/Source/Blade/Public/BladeEnemyCharacter.h
+++ b/Source/Blade/Public/BladeEnemyCharacter.h
@@ -13,7 +13,8 @@ class BLADE_API ABladeEnemyCharacter : public ABladeCharacterBase
 	GENERATED_BODY()
 
 public:
-	explicit ABladeEnemyCharacter(const FObjectInitializer& ObjectInitializer);
+	ABladeEnemyCharacter();
+
 	virtual void PostInitializeComponents() override;
 	virtual void Die() override;
 

--- a/Source/Blade/Public/BladePlayerCharacter.h
+++ b/Source/Blade/Public/BladePlayerCharacter.h
@@ -4,12 +4,20 @@
 #include "BladeCharacterBase.h"
 #include "BladePlayerCharacter.generated.h"
 
+class UAIPerceptionStimuliSourceComponent;
+
 UCLASS()
 class BLADE_API ABladePlayerCharacter : public ABladeCharacterBase
 {
 	GENERATED_BODY()
 
 public:
+	ABladePlayerCharacter();
+
 	virtual void HandleHealthChanged(float DeltaValue, const FGameplayTagContainer& EventTags) override;
 	virtual void Die() override;
+
+protected:
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "AI Perception")
+	UAIPerceptionStimuliSourceComponent* StimuliSourceComponent;
 };


### PR DESCRIPTION
## Description
- Should not automatically register all pawns as sources.
- Add stimuli source component to register AI sense.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Style modification
